### PR TITLE
Add --quiet option, fix percentage calculation, add multipart view/cleanup

### DIFF
--- a/s3-mp-cleanup.py
+++ b/s3-mp-cleanup.py
@@ -28,7 +28,7 @@ def main(uri, cancel):
             break
     else:
         if cancel:
-            print("No multipart upload {} found in {}".format(cancel, uri))
+            print("No multipart upload {} found for {}".format(cancel, uri))
         
     
 

--- a/s3-mp-cleanup.py
+++ b/s3-mp-cleanup.py
@@ -17,7 +17,6 @@ def main(uri, cancel):
 
     s3 = boto.connect_s3()
     bucket = s3.lookup(split_rs.netloc)
-    key = bucket.get_key(split_rs.path)
     
     mpul = bucket.list_multipart_uploads()
     for mpu in mpul:
@@ -29,6 +28,7 @@ def main(uri, cancel):
     else:
         if cancel:
             print("No multipart upload {} found for {}".format(cancel, uri))
+            sys.exit(1)
         
     
 

--- a/s3-mp-cleanup.py
+++ b/s3-mp-cleanup.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+import argparse
+import urlparse
+import boto
+import sys
+
+parser = argparse.ArgumentParser(description="View or remove incomplete S3 multipart uploads",
+        prog="s3-mp-cleanup")
+parser.add_argument("uri", type=str, help="The S3 URI to operate on")
+parser.add_argument("-c", "--cancel", help="Upload ID to cancel", type=str, required=False)
+
+def main(uri, cancel):
+    # Check that dest is a valid S3 url
+    split_rs = urlparse.urlsplit(uri)
+    if split_rs.scheme != "s3":
+        raise ValueError("'%s' is not an S3 url" % uri)
+
+    s3 = boto.connect_s3()
+    bucket = s3.lookup(split_rs.netloc)
+    key = bucket.get_key(split_rs.path)
+    
+    mpul = bucket.list_multipart_uploads()
+    for mpu in mpul:
+        if not cancel:
+            print('s3-mp-cleanup.py s3://{}/{} -c {}  # {} {}'.format(mpu.bucket.name, mpu.key_name, mpu.id, mpu.initiator.display_name, mpu.initiated))
+        elif cancel == mpu.id:
+            bucket.cancel_multipart_upload(mpu.key_name, mpu.id)
+            break
+    else:
+        if cancel:
+            print("No multipart upload {} found in {}".format(cancel, uri))
+        
+    
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    arg_dict = vars(args)
+    main(**arg_dict)

--- a/s3-mp-upload.py
+++ b/s3-mp-upload.py
@@ -64,7 +64,7 @@ def do_part_upload(args):
         raise Exception("Unexpectedly tried to read an empty chunk")
 
     def progress(x,y):
-        logger.info("Part %d: %0.2f%%" % (i+1, 1.*x/y))
+        logger.debug("Part %d: %0.2f%%" % (i+1, 100.*x/y))
 
     # Do the upload
     t1 = time.time()

--- a/s3-mp-upload.py
+++ b/s3-mp-upload.py
@@ -4,7 +4,6 @@ from cStringIO import StringIO
 import logging
 from math import ceil
 from multiprocessing import Pool
-import sys
 import time
 import urlparse
 

--- a/s3-mp-upload.py
+++ b/s3-mp-upload.py
@@ -21,6 +21,7 @@ parser.add_argument("-f", "--force", help="Overwrite an existing S3 key",
 parser.add_argument("-s", "--split", help="Split size, in Mb", type=int, default=50)
 parser.add_argument("-rrs", "--reduced-redundancy", help="Use reduced redundancy storage. Default is standard.", default=False,  action="store_true")
 parser.add_argument("-v", "--verbose", help="Be more verbose", default=False, action="store_true")
+parser.add_argument("-q", "--quiet", help="Be less verbose (for use in cron jobs)", default=False, action="store_true")
 
 logger = logging.getLogger("s3-mp-upload")
 
@@ -75,7 +76,7 @@ def do_part_upload(args):
     s = len(data)/1024./1024.
     logger.info("Uploaded part %s (%0.2fM) in %0.2fs at %0.2fMbps" % (i+1, s, t2, s/t2))
 
-def main(src, dest, num_processes=2, split=50, force=False, reduced_redundancy=False, verbose=False):
+def main(src, dest, num_processes=2, split=50, force=False, reduced_redundancy=False, verbose=False, quiet=False):
     # Check that dest is a valid S3 url
     split_rs = urlparse.urlsplit(dest)
     if split_rs.scheme != "s3":
@@ -150,6 +151,8 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     args = parser.parse_args()
     arg_dict = vars(args)
+    if arg_dict['quiet'] == True:
+        logger.setLevel(logging.WARNING)
     if arg_dict['verbose'] == True:
         logger.setLevel(logging.DEBUG)
     logger.debug("CLI args: %s" % args)


### PR DESCRIPTION
Hi, just a few mostly optional things for use in cronjobs.

Also added a small tool to view and cleanup incomplete multipart uploads, as the automatic boto cleanup doesn't always work (sometimes S3 throws random 500s and also does so when boto tries to remove the failed upload). And these then hang around forever and the space is charged for.
