### PR TITLE
Fixes retries for uploads and downloads

### DIFF
--- a/s3-mp-cleanup.py
+++ b/s3-mp-cleanup.py
@@ -17,7 +17,7 @@ def main(uri, cancel):
 
     s3 = boto.connect_s3()
     bucket = s3.lookup(split_rs.netloc)
-    
+
     mpul = bucket.list_multipart_uploads()
     for mpu in mpul:
         if not cancel:
@@ -29,8 +29,8 @@ def main(uri, cancel):
         if cancel:
             print("No multipart upload {} found for {}".format(cancel, uri))
             sys.exit(1)
-        
-    
+
+
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/s3-mp-copy.py
+++ b/s3-mp-copy.py
@@ -21,7 +21,7 @@ parser.add_argument("-np", "--num-processes", help="Number of processors to use"
 parser.add_argument("-f", "--force", help="Overwrite an existing S3 key",
         action="store_true")
 parser.add_argument("-s", "--split", help="Split size, in Mb", type=int, default=50)
-parser.add_argument("-rrs", "--reduced-redundancy", help="Use reduced redundancy storage. Default is standard.", 
+parser.add_argument("-rrs", "--reduced-redundancy", help="Use reduced redundancy storage. Default is standard.",
         default=False,  action="store_true")
 parser.add_argument("-v", "--verbose", help="Be more verbose", default=False, action="store_true")
 
@@ -41,7 +41,7 @@ def do_part_copy(args):
                  function definition.
 
                  The arguments are: S3 src bucket name, S3 key name, S3 dest
-                 bucket_name, MultiPartUpload id, the part number, 
+                 bucket_name, MultiPartUpload id, the part number,
                  part start position, part stop position
     """
     # Multiprocessing args lameness
@@ -84,7 +84,7 @@ def main(src, dest, num_processes=2, split=50, force=False, reduced_redundancy=F
     s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
     dest_bucket = s3.lookup( dest_bucket_name )
     dest_key    = dest_bucket.get_key( dest_key_name )
-    
+
     # See if we're overwriting an existing key
     if dest_key is not None:
         if not force:
@@ -113,7 +113,7 @@ def main(src, dest, num_processes=2, split=50, force=False, reduced_redundancy=F
     mpu = dest_bucket.initiate_multipart_upload( dest_key_name, reduced_redundancy=reduced_redundancy)
     logger.info("Initialized copy: %s" % mpu.id)
 
-    # Generate arguments for invocations of do_part_copy 
+    # Generate arguments for invocations of do_part_copy
     def gen_args(num_parts):
         cur_pos = 0
         for i in range(num_parts):

--- a/s3-mp-download.py
+++ b/s3-mp-download.py
@@ -79,7 +79,7 @@ def do_part_download(args):
         else:
             time.sleep(3)
             current_tries += 1
-            do_part_download(bucket_name, key_name, fname, min_byte, max_byte, split, secure, max_tries, current_tries)
+            do_part_download((bucket_name, key_name, fname, min_byte, max_byte, split, secure, max_tries, current_tries))
 
 def gen_byte_ranges(size, num_parts):
     part_size = int(ceil(1. * size / num_parts))

--- a/s3-mp-download.py
+++ b/s3-mp-download.py
@@ -23,7 +23,7 @@ parser.add_argument("--insecure", dest='secure', help="Use HTTP for connection",
         default=True, action="store_false")
 parser.add_argument("-t", "--max-tries", help="Max allowed retries for http timeout", type=int, default=5)
 parser.add_argument("-v", "--verbose", help="Be more verbose", default=False, action="store_true")
-parser.add_argument("-q", "--quiet", help="Be less verbose (for use in cron jobs)", 
+parser.add_argument("-q", "--quiet", help="Be less verbose (for use in cron jobs)",
         default=False, action="store_true")
 
 logger = logging.getLogger("s3-mp-download")
@@ -121,7 +121,7 @@ def main(src, dest, num_processes=2, split=32, force=False, verbose=False, quiet
     resp = s3.make_request("HEAD", bucket=bucket, key=key)
     if resp is None:
       raise ValueError("response is invalid.")
-      
+
     size = int(resp.getheader("content-length"))
     logger.debug("Got headers: %s" % resp.getheaders())
 
@@ -137,7 +137,7 @@ def main(src, dest, num_processes=2, split=32, force=False, verbose=False, quiet
         # Touch the file
         fd = os.open(dest, os.O_CREAT)
         os.close(fd)
-    
+
         size_mb = size / 1024 / 1024
         num_parts = (size_mb+(-size_mb%split))//split
 

--- a/s3-mp-upload.py
+++ b/s3-mp-upload.py
@@ -87,7 +87,7 @@ def do_part_upload(args):
         else:
             time.sleep(3)
             current_tries += 1
-            do_part_download(bucket_name, mpu_id, fname, i, start, size, secure, max_tries, current_tries)
+            do_part_upload((bucket_name, mpu_id, fname, i, start, size, secure, max_tries, current_tries))
 
 def main(src, dest, num_processes=2, split=50, force=False, reduced_redundancy=False, verbose=False, quiet=False, secure=True, max_tries=5):
     # Check that dest is a valid S3 url


### PR DESCRIPTION
Thanks for writing this library!

Fixes an issue where retries would fail because 9 arguments were passed into the `do_part_upload()` and `do_part_download()` functions instead of a tuple[0], and removes trailing whitespace.

[0]: `ERROR:s3-mp-download:do_part_download() takes exactly 1 argument (9 given)`
