### PR TITLE
Upgrade s3-multipart-upload.py to boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 boto
+boto3>=1.1.2
+botocore>=1.1.12
 argparse

--- a/s3-mp-download.py
+++ b/s3-mp-download.py
@@ -45,7 +45,7 @@ def do_part_download(args):
                  chunk size, and part number
     """
     bucket_name, key_name, fname, min_byte, max_byte, split, secure, max_tries, current_tries = args
-    conn = boto.connect_s3(calling_format=OrdinaryCallingFormat())
+    conn = boto.connect_s3()
     conn.is_secure = secure
 
     # Make the S3 request
@@ -107,7 +107,6 @@ def main(src, dest, num_processes=2, split=32, force=False, verbose=False, quiet
 
     # Split out the bucket and the key
     s3 = boto.connect_s3()
-    s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
     s3.is_secure = secure
     logger.debug("split_rs: %s" % str(split_rs))
     bucket = s3.lookup(split_rs.netloc)
@@ -159,7 +158,7 @@ def main(src, dest, num_processes=2, split=32, force=False, verbose=False, quiet
             logger.error(err)
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
     args = parser.parse_args()
     arg_dict = vars(args)
     if arg_dict['quiet'] == True:

--- a/s3-mp-upload.py
+++ b/s3-mp-upload.py
@@ -190,19 +190,25 @@ def main(src, dest, num_processes=DEFAULTS["p_transfers"], force=False,
 
     # Generate a destination object name, if necessary
     if not s3_dest_path or s3_dest_path == "/":
+        # Destination is bucket root
         source_file = os.path.split(src.name)[1]
         s3_dest_obj = source_file
     elif s3_dest_path.endswith("/"):
+        # Destination is partial-path, not object
         source_file = os.path.split(src.name)[1]
         s3_dest_obj = os.path.join(s3_dest_path, source_file)
+    elif s3_dest_path.startswith("/") and s3_dest_path.count("/") == 1:
+        # Destination is named object, in bucket root
+        s3_dest_obj = s3_dest_path.lstrip("/")
     else:
+        # Full path
         s3_dest_obj = s3_dest_path
 
     # Check if destination object exists
     try:
         client.get_object(Bucket=s3_bucket, Key=s3_dest_obj)
     except ClientError as e:
-        if "NoSuchKey" in e.message:
+        if "NoSuchKey" in str(e):
             # It's ok if the object doesn't exist; We'll create it.
             pass
         else:

--- a/s3-mp-upload.py
+++ b/s3-mp-upload.py
@@ -1,177 +1,323 @@
 #!/usr/bin/env python
+"""
+A script to assist in uploading large files to S3.
+
+Uses some code from documentation in boto3.s3.transfer pretty much verbatim
+(ProgressPercentage class, upload retry loop)
+"""
+#pylint: disable=C0103
+
 import argparse
-from cStringIO import StringIO
 import logging
-from math import ceil
-from multiprocessing import Pool
+import os
+import re
+import sys
+import threading
 import time
 import urlparse
 
-import boto
-from boto.s3.connection import OrdinaryCallingFormat
+import boto3
+from boto3.s3.transfer import TransferConfig, S3Transfer
+from botocore.exceptions import ClientError
 
-parser = argparse.ArgumentParser(description="Transfer large files to S3",
-        prog="s3-mp-upload")
-parser.add_argument("src", type=file, help="The file to transfer")
-parser.add_argument("dest", help="The S3 destination object")
-parser.add_argument("-np", "--num-processes", help="Number of processors to use",
-        type=int, default=2)
-parser.add_argument("-f", "--force", help="Overwrite an existing S3 key",
-        action="store_true")
-parser.add_argument("-s", "--split", help="Split size, in Mb", type=int, default=50)
-parser.add_argument("-rrs", "--reduced-redundancy", help="Use reduced redundancy storage. Default is standard.", default=False,  action="store_true")
-parser.add_argument("--insecure", dest='secure', help="Use HTTP for connection",
-        default=True, action="store_false")
-parser.add_argument("-t", "--max-tries", help="Max allowed retries for http timeout", type=int, default=5)
-parser.add_argument("-v", "--verbose", help="Be more verbose", default=False, action="store_true")
-parser.add_argument("-q", "--quiet", help="Be less verbose (for use in cron jobs)", default=False, action="store_true")
+LOG = logging.getLogger("s3-mp-upload")
 
-logger = logging.getLogger("s3-mp-upload")
+UNIT_MULTIPLIERS = {
+    "byte": 1,
+    "kilobyte": 1000,
+    "kB": 1000,
+    "kibibyte": 1024,
+    "KiB": 1024,
+    "KB": 1024,
+    "megabyte": 1000**2,
+    "MB": 1000**2,
+    "mebibyte": 1024**2,
+    "MiB": 1024**2,
+    "gigabyte": 1000**3,
+    "GB": 1000**3,
+    "gibibyte": 1024**3,
+    "GiB": 1024**3,
+    "terabyte": 1000**4,
+    "TB": 1000**4,
+    "tebibyte": 1024**4,
+    "TiB": 1024**4,
+    "petabyte": 1000**5,
+    "PB": 1000**5,
+    "pebibyte": 1024**5,
+    "PiB": 1024**5,
+    "exabyte": 1000**6,
+    "EB": 1000**6,
+    "exbibyte": 1024**6,
+    "EiB": 1024**6,
+    "zettabyte": 1000**7,
+    "ZB": 1000**7,
+    "zebibyte": 1024**7,
+    "ZiB": 1024**7,
+    "yottabyte": 1000**8,
+    "YB": 1000**8,
+    "yobibyte": 1024**8,
+    "YiB": 1024**8,
+}
 
-def do_part_upload(args):
+DEFAULTS = {
+    "p_transfers": 2,
+    "max_tries": 10,
+    "split": "50 MiB",
+    "chunk_threshold": "50 MiB",
+    # Wait 10 seconds before initial retry, if there was an error during upload.
+    # NOTE: This value will double with each failure
+    "retry_sleep": 10,
+}
+
+def chunk_bytes(chunk_string, default_unit="byte", default_multiplier="MiB"):
     """
-    Upload a part of a MultiPartUpload
+    Convert a string to the total bytes that it represents
 
-    Open the target file and read in a chunk. Since we can't pickle
-    S3Connection or MultiPartUpload objects, we have to reconnect and lookup
-    the MPU object with each part upload.
-
-    :type args: tuple of (string, string, string, int, int, int)
-    :param args: The actual arguments of this method. Due to lameness of
-                 multiprocessing, we have to extract these outside of the
-                 function definition.
-
-                 The arguments are: S3 Bucket name, MultiPartUpload id, file
-                 name, the part number, part offset, part size
+    :param str chunk_string: A string describing a multiple of bytes to return.
+    :param str default_unit: The default unit to use (bytes, of course)
+    :param str default_multiplier: The multiplier to use, if chunk_string is just a digit.
+    :return The total bytes represented by the string
+    :rtype int
+    :raises ValueError: If the string's fields look bad (count or unit multiplier)
+    :raises RuntimeError: If the string was not parseable.
     """
-    # Multiprocessing args lameness
-    bucket_name, mpu_id, fname, i, start, size, secure, max_tries, current_tries = args
-    logger.debug("do_part_upload got args: %s" % (args,))
 
-    # Connect to S3, get the MultiPartUpload
-    # s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
-    s3 = boto.connect_s3()
-    s3.is_secure = secure
-    bucket = s3.lookup(bucket_name)
-    mpu = None
-    for mp in bucket.list_multipart_uploads():
-        if mp.id == mpu_id:
-            mpu = mp
-            break
-    if mpu is None:
-        raise Exception("Could not find MultiPartUpload %s" % mpu_id)
+    if chunk_string.isdigit():
+        # Assume the default_unit (byte) and multiplier (MiB)
+        return UNIT_MULTIPLIERS[default_unit] * (UNIT_MULTIPLIERS[default_multiplier] * int(chunk_string))
 
-    # Read the chunk from the file
-    fp = open(fname, 'rb')
-    fp.seek(start)
-    data = fp.read(size)
-    fp.close()
-    if not data:
-        raise Exception("Unexpectedly tried to read an empty chunk")
+    if "." in chunk_string:
+        error_message = "Split string must use whole numbers!: {0}".format(chunk_string)
+        LOG.error(error_message)
+        raise ValueError(error_message)
 
-    def progress(x,y):
-        logger.debug("Part %d: %0.2f%%" % (i+1, 100.*x/y))
+    result = re.match(r'^(\d+)\s*(\S+)?', chunk_string, flags=re.UNICODE)
 
-    try:
-        # Do the upload
-        t1 = time.time()
-        mpu.upload_part_from_file(StringIO(data), i+1, cb=progress)
+    if not result:
+        error_message = "Could not parse split string: {0}!".format(chunk_string)
+        LOG.error(error_message)
+        raise RuntimeError(error_message)
 
-        # Print some timings
-        t2 = time.time() - t1
-        s = len(data)/1024./1024.
-        logger.info("Uploaded part %s (%0.2fM) in %0.2fs at %0.2fMBps" % (i+1, s, t2, s/t2))
-    except Exception, err:
-        logger.debug("Retry request %d of max %d times" % (current_tries, max_tries))
-        if (current_tries > max_tries):
-            logger.error(err)
-        else:
-            time.sleep(3)
-            current_tries += 1
-            do_part_download(bucket_name, mpu_id, fname, i, start, size, secure, max_tries, current_tries)
+    count_s, multiplier = result.groups()
+    count = int(count_s)
 
-def main(src, dest, num_processes=2, split=50, force=False, reduced_redundancy=False, verbose=False, quiet=False, secure=True, max_tries=5):
-    # Check that dest is a valid S3 url
-    split_rs = urlparse.urlsplit(dest)
-    if split_rs.scheme != "s3":
-        raise ValueError("'%s' is not an S3 url" % dest)
+    if multiplier is None:
+        # chunk_string has trailing whitespace and no unit
+        multiplier = default_multiplier
 
-    # s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
-    s3 = boto.connect_s3()
-    s3.is_secure = secure
-    bucket = s3.lookup(split_rs.netloc)
-    if bucket == None:
-        raise ValueError("'%s' is not a valid bucket" % split_rs.netloc)
-    key = bucket.get_key(split_rs.path)
-    # See if we're overwriting an existing key
-    if key is not None:
-        if not force:
-            raise ValueError("'%s' already exists. Specify -f to overwrite it" % dest)
+    if multiplier.lower().endswith("bytes"):
+        # Chop off the ending 's' of '<something>bytes', if necessary
+        multiplier = multiplier[:-1]
 
-    # Determine the splits
-    part_size = max(5*1024*1024, 1024*1024*split)
-    src.seek(0,2)
-    size = src.tell()
-    num_parts = int(ceil(size / part_size))
-
-    # If file is less than 5M, just upload it directly
-    if size < 5*1024*1024:
-        src.seek(0)
-        t1 = time.time()
-        k = boto.s3.key.Key(bucket,split_rs.path)
-        k.set_contents_from_file(src)
-        t2 = time.time() - t1
-        s = size/1024./1024.
-        logger.info("Finished uploading %0.2fM in %0.2fs (%0.2fMBps)" % (s, t2, s/t2))
-        return
-
-    # Create the multi-part upload object
-    mpu = bucket.initiate_multipart_upload(split_rs.path, reduced_redundancy=reduced_redundancy)
-    logger.info("Initialized upload: %s" % mpu.id)
-
-    # Generate arguments for invocations of do_part_upload
-    def gen_args(num_parts, fold_last):
-        for i in range(num_parts+1):
-            part_start = part_size*i
-            if i == (num_parts-1) and fold_last is True:
-                yield (bucket.name, mpu.id, src.name, i, part_start, part_size*2, secure, max_tries, 0)
+    matching_multiplier = None
+    if multiplier in UNIT_MULTIPLIERS:
+        matching_multiplier = multiplier
+    else:
+        for mp_name in UNIT_MULTIPLIERS:
+            if multiplier.lower() == mp_name.lower():
+                matching_multiplier = mp_name
                 break
-            else:
-                yield (bucket.name, mpu.id, src.name, i, part_start, part_size, secure, max_tries, 0)
 
+    if not matching_multiplier:
+        error_message = "Invalid units specified in split string: {0}!".format(chunk_string)
+        LOG.error(error_message)
+        raise ValueError(error_message)
 
-    # If the last part is less than 5M, just fold it into the previous part
-    fold_last = ((size % part_size) < 5*1024*1024)
+    return UNIT_MULTIPLIERS[default_unit] * (UNIT_MULTIPLIERS[matching_multiplier] * count)
 
-    # Do the thing
+# pylint: disable=C0111,R0903
+class ProgressPercentage(object):
+    def __init__(self, filename):
+        self._filename = filename
+        self._size = float(os.path.getsize(filename))
+        self._seen_so_far = 0
+        self._lock = threading.Lock()
+    def __call__(self, bytes_amount):
+        # To simplify we'll assume this is hooked up
+        # to a single filename.
+        with self._lock:
+            self._seen_so_far += bytes_amount
+            percentage = (self._seen_so_far / self._size) * 100
+            sys.stdout.write(
+                "\r%s  %s / %s  (%.2f%%)" % (self._filename, self._seen_so_far,
+                                             self._size, percentage))
+            sys.stdout.flush()
+
+#pylint: disable=R0914,W0613
+def main(src, dest, num_processes=DEFAULTS["p_transfers"], force=False,
+         chunk=DEFAULTS["split"], reduced_redundancy=False, secure=True,
+         max_tries=DEFAULTS["max_tries"], verbose=False, quiet=False,
+         retry_sleep=DEFAULTS["retry_sleep"]):
+    """
+    Send a file to S3, potentially in parallel chunked transfers.
+
+    :param file src: File-like object that supports f.name attribute, to use as source of transfer.
+    :param str dest: The destination s3 object uri, to transfer the source file to.
+    (This is filled-in with the source filename if the destination uri is an incomplete object path)
+    :param int num_processes: Number of parallel transfers.
+    :param bool force: Set to True if overwriting destination s3 object is ok.
+    :param str chunk: A string describing the chunk size to use.
+    :param bool reduced_redundancy: Unused parameter for compatibility purposes.
+    :param bool secure: Unused parameter for compatibility purposes.
+    :param bool verbose: Set to true, for more output.
+    :param bool quiet: Set to true, for less output.
+    :param int retry_sleep: The number of seconds to sleep between upload attempts, if there is a failure.
+    (This value is doubled with each failure)
+    :return None
+    :rtype None
+    """
+    # Determine the size of chunks, based on chunk-string multiplier
+    chunk_size = chunk_bytes(chunk)
+
+    # Get S3 path
+    dest_uri_parts = urlparse.urlsplit(dest)
+    if dest_uri_parts.scheme != "s3":
+        error_message = "Destination needs to be an S3 url!: {0}".format(dest)
+        LOG.error(error_message)
+        raise ValueError(error_message)
+
+    s3_bucket = dest_uri_parts.netloc
+    s3_dest_path = dest_uri_parts.path
+
+    client = boto3.client("s3", use_ssl=True)
+
+    # Check that bucket exists
     try:
-        # Create a pool of workers
-        pool = Pool(processes=num_processes)
-        t1 = time.time()
-        pool.map_async(do_part_upload, gen_args(num_parts, fold_last)).get(9999999)
-        # Print out some timings
-        t2 = time.time() - t1
-        s = size/1024./1024.
-        # Finalize
-        src.close()
-        mpu.complete_upload()
-        logger.info("Finished uploading %0.2fM in %0.2fs (%0.2fMBps)" % (s, t2, s/t2))
-    except KeyboardInterrupt:
-        logger.warn("Received KeyboardInterrupt, canceling upload")
-        pool.terminate()
-        mpu.cancel_upload()
-    except Exception, err:
-        logger.error("Encountered an error, canceling upload")
-        logger.error(err)
-        mpu.cancel_upload()
+        client.head_bucket(Bucket=s3_bucket)
+    except ClientError as e:
+        LOG.error("Could not inspect s3 bucket %s!", s3_bucket)
+        raise
+
+    # Generate a destination object name, if necessary
+    if not s3_dest_path or s3_dest_path == "/":
+        source_file = os.path.split(src.name)[1]
+        s3_dest_obj = source_file
+    elif s3_dest_path.endswith("/"):
+        source_file = os.path.split(src.name)[1]
+        s3_dest_obj = os.path.join(s3_dest_path, source_file)
+    else:
+        s3_dest_obj = s3_dest_path
+
+    # Check if destination object exists
+    try:
+        client.get_object(Bucket=s3_bucket, Key=s3_dest_obj)
+    except ClientError as e:
+        if "NoSuchKey" in e.message:
+            # It's ok if the object doesn't exist; We'll create it.
+            pass
+        else:
+            LOG.error("Error checking for destination object!")
+            raise
+    else:
+        # Key exists
+        if not force:
+            error_message = "{0} alredy exists in {1}. Use --force to overwrite!".format(s3_dest_obj, s3_bucket)
+            LOG.error(error_message)
+            raise RuntimeError(error_message)
+
+    # Transfer config
+    config = TransferConfig(
+        multipart_threshold=chunk_bytes(DEFAULTS["chunk_threshold"]),
+        multipart_chunksize=chunk_size,
+        max_concurrency=num_processes,
+        # NOTE: boto3.transfer.upload_file() doesn't currently have an equivalent of num_download_attempts.
+        # We'll implement this ourselves, for now.
+        #num_download_attempts=max_tries,
+    )
+
+    # Start transfer
+    LOG.info("Starting upload")
+    transfer = S3Transfer(client, config)
+    callback_fn = None
+    if verbose:
+        callback_fn = ProgressPercentage(src.name)
+
+    retry_interval = retry_sleep
+    last_exception = RuntimeError("Upload and retries failed, but without raising an exception?!")
+    #pylint: disable=W0612
+    for attempt in range(max_tries):
+        #pylint: disable=W0703
+        try:
+            transfer.upload_file(src.name, s3_bucket, s3_dest_obj, callback=callback_fn)
+        except Exception as e:
+            LOG.error("Error during upload!", exc_info=True)
+            last_exception = e
+            if verbose:
+                # Reset upload counter
+                callback_fn = ProgressPercentage(src.name)
+        else:
+            sys.stdout.write("\r\n")
+            sys.stdout.flush()
+            LOG.info("Finished upload")
+            return
+        LOG.warning("Sleeping for %d seconds before next attempt", retry_interval)
+        time.sleep(retry_interval)
+        retry_interval *= 2
+    LOG.error("Maximum upload attempts exceeded!")
+    raise last_exception
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
+    LOG.setLevel(logging.INFO)
+    ch = logging.StreamHandler()
+    formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+    ch.setFormatter(formatter)
+    LOG.addHandler(ch)
+
+    parser = argparse.ArgumentParser(
+        description="Upload large files to S3 using parallel chunked transfers",)
+
+    parser.add_argument("src",
+                        type=file,
+                        help="Source file to transfer",)
+
+    parser.add_argument("dest",
+                        help="Destination S3 object of transfer",)
+
+    parser.add_argument("-np", "--num-processes",
+                        type=int,
+                        default=DEFAULTS["p_transfers"],
+                        help="Number of parallel transfers (default: {0})".format(DEFAULTS["p_transfers"]),)
+
+    parser.add_argument("-f", "--force",
+                        action="store_true",
+                        help="Overwrite any pre-existing S3 object with the same name",)
+
+    parser.add_argument("-s", "--split",
+                        dest="chunk",
+                        default=DEFAULTS["split"],
+                        help="Split size to use (default: {0}). Accepts suffixes: {1}".format(
+                            DEFAULTS["split"], ", ".join(sorted(UNIT_MULTIPLIERS.keys()))),)
+
+    parser.add_argument("--rrs", "--reduced-redundancy",
+                        dest="reduced_redundancy",
+                        action="store_true",
+                        help="Unused parameter, here for compatibility purposes",)
+
+    parser.add_argument("--insecure",
+                        dest="secure",
+                        action="store_false",
+                        help="Unused parameter, here for compatibility purposes",)
+
+    parser.add_argument("-t", "--max-tries",
+                        type=int,
+                        default=DEFAULTS["max_tries"],
+                        help="Maximum upload attempts, before failure (default: {0})".format(DEFAULTS["max_tries"]),)
+
+    parser.add_argument("-v", "--verbose",
+                        action="store_true",
+                        help="Print more output",)
+
+    parser.add_argument("-q", "--quiet",
+                        action="store_true",
+                        help="Print less output",)
+
     args = parser.parse_args()
-    arg_dict = vars(args)
-    if arg_dict['quiet'] == True:
-        logger.setLevel(logging.WARNING)
-    if arg_dict['verbose'] == True:
-        logger.setLevel(logging.DEBUG)
-    logger.debug("CLI args: %s" % args)
-    main(**arg_dict)
+    if args.quiet:
+        LOG.setLevel(logging.WARNING)
+    if args.verbose:
+        LOG.setLevel(logging.DEBUG)
+
+    args_dict = vars(args)
+
+    LOG.debug("Args: %s", args_dict)
+    main(**args_dict)

--- a/s3-mp-upload.py
+++ b/s3-mp-upload.py
@@ -49,7 +49,8 @@ def do_part_upload(args):
     logger.debug("do_part_upload got args: %s" % (args,))
 
     # Connect to S3, get the MultiPartUpload
-    s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
+    # s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
+    s3 = boto.connect_s3()
     s3.is_secure = secure
     bucket = s3.lookup(bucket_name)
     mpu = None
@@ -95,7 +96,8 @@ def main(src, dest, num_processes=2, split=50, force=False, reduced_redundancy=F
     if split_rs.scheme != "s3":
         raise ValueError("'%s' is not an S3 url" % dest)
 
-    s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
+    # s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
+    s3 = boto.connect_s3()
     s3.is_secure = secure
     bucket = s3.lookup(split_rs.netloc)
     if bucket == None:

--- a/s3-mp-upload.py
+++ b/s3-mp-upload.py
@@ -197,12 +197,9 @@ def main(src, dest, num_processes=DEFAULTS["p_transfers"], force=False,
         # Destination is partial-path, not object
         source_file = os.path.split(src.name)[1]
         s3_dest_obj = os.path.join(s3_dest_path, source_file)
-    elif s3_dest_path.startswith("/") and s3_dest_path.count("/") == 1:
-        # Destination is named object, in bucket root
-        s3_dest_obj = s3_dest_path.lstrip("/")
     else:
-        # Full path
-        s3_dest_obj = s3_dest_path
+        # Full path (always strip leading /)
+        s3_dest_obj = s3_dest_path.lstrip("/")
 
     # Check if destination object exists
     try:


### PR DESCRIPTION
We ran into an issue where `do_part_upload()` would intermittently fail when looking for a matching multi-part upload id. It looks like boto libraries were making AWS S3 API calls _each time_ we examined attributes of an multi-part upload object returned by `list_multipart_uploads()`, and it got to be more flaky when we had multiple subprocesses making multiple requests for mpu ids, for each chunk of a large file they were processing.

We tried using boto3 to perform the same upload task, and it worked out well. :)

If you're interested, this PR has the updated boto3 version of s3-multipart-upload.py.
